### PR TITLE
make buildhelper compatible with previous tsconfig

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -42,10 +42,11 @@ const tsOptions = {
   stripInternal: true,
   noUnusedLocals: true,
   strict: true,
-  target: "es2020",
+  target: "es6",
   module: "es2020",
   newLine: "lf",
   declaration: true,
+  declarationMap: true,
   moduleResolution: "node"
 }
 


### PR DESCRIPTION
The move from each codemirror 6 repo having its own separate rollup and tsconfig to a single buildhelper (e.g. with [`@codemirror/autocomplete`](https://github.com/codemirror/autocomplete/blob/45b277af094d22235abc3510c22f3d18f0f782d7/tsconfig.local.json)) broke `dist` compatibility due to changes in `target`, `module`, etc.

One example is the nullish coalescing operator found in the `dist` of `@codemirror/autocomplete`, resulting in the following error:
```js
./node_modules/@codemirror/autocomplete/dist/index.js 134:93
Module parse failed: Unexpected token (134:93)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|     if (!addStart && !addEnd)
|         return expr;
>     return new RegExp(`${addStart ? "^" : ""}(?:${source})${addEnd ? "$" : ""}`, expr.flags ?? (expr.ignoreCase ? "i" : ""));
| }
```

Edit: Oops. On further reading of buildhelper, I realized the tsconfig used in the build step was contained inside of `src/build.ts` and was not `/tsconfig.json`. Last commit fixes that.