### PR TITLE
Add pure annotations option

### DIFF
--- a/bin/cm-buildhelper.js
+++ b/bin/cm-buildhelper.js
@@ -1,15 +1,28 @@
 #!/usr/bin/env node
 
-const {build} = require("../src/build.js")
+const {build, defaultBuildOptions} = require("../src/build.js")
 const {resolve} = require("path")
 
 let args = process.argv.slice(2)
 
-if (args.length != 1) {
-  console.log("Usage: cm-buildhelper src/mainfile.ts")
+if (args.length == 0) {
+  console.log("Usage: cm-buildhelper src/mainfile.ts [--source-map] [--disable-pure-annotations]")
   process.exit(1)
 }
 
-build(resolve(args[0])).then(result => {
+const filePath = resolve(args[0])
+const buildOptions = {...defaultBuildOptions}
+for (const arg of args.slice(1)) {
+  switch (arg) {
+    case "--disable-pure-annotations":
+      buildOptions.addPureAnnotations = false
+      break
+    case "--source-map":
+      buildOptions.sourceMap = true
+      break
+  }
+}
+
+build(filePath, buildOptions).then(result => {
   if (!result) process.exit(1)
 })


### PR DESCRIPTION
Adds `--source-map` and `--disable-pure-annotations` command line options to cm-buildhelper.

We're using https://github.com/replit/codemirror-emacs and found it not working correctly in production mode, which I traced to the presence of incorrect `/*@__PURE__*/` annotations in the index.js built by cm-buildhelper, one of which results in a crucial method call being stripped by Terser. Rather than rewrite perfectly valid code to work around it, I've instead added an option to omit the  `/*@__PURE__*/` annotations here. I admit I'm not sure what the consequences are for tree-shaking in this case, if any.